### PR TITLE
Import of the adafruit_itertools lib changed at at some point

### DIFF
--- a/teaandtechtime_fft.py
+++ b/teaandtechtime_fft.py
@@ -42,7 +42,7 @@ Implementation Notes
 
 # imports
 from math import pi, sin, cos, sqrt, pow, log
-from adafruit_itertools import islice, count
+from adafruit_itertools.adafruit_itertools import islice, count
 import array
 
 __version__ = "0.0.0-auto.0"


### PR DESCRIPTION
Now the Submodule must be named.

At least since version 1.1.6. If I understand it right, since [1.0.1](https://github.com/adafruit/Adafruit_CircuitPython_IterTools/tree/1.0.1).